### PR TITLE
Add Steam game finder web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Vibecoding Steam Lookup
+
+This project is a small Node.js application that exposes an HTTP API for looking up Steam games and serves a single page application that displays the banner, description, and screenshots for a queried game.
+
+## Prerequisites
+
+You need a recent [Node.js](https://nodejs.org/) installation. The official installer ships with both `node` and `npm` and is the easiest way to set things up on Windows:
+
+1. Download the *LTS* installer from [nodejs.org](https://nodejs.org/).
+2. Run the installer and keep the default options so that the `node` and `npm` executables are added to your `PATH` automatically.
+3. Close the PowerShell or Command Prompt session you used before and open a new one so the updated `PATH` is picked up.
+
+To verify the installation run:
+
+```powershell
+node -v
+npm -v
+```
+
+Both commands should print version numbers. If they do not, reboot Windows or double‑check the installation steps above.
+
+## Installation
+
+From a terminal that recognises `npm`, navigate into the project folder and install the dependencies:
+
+```powershell
+cd path\to\Vibecoding
+npm install
+```
+
+The project currently only uses the built‑in Node.js modules, so `npm install` will finish quickly, but it also creates the `node_modules` directory that `npm start` expects.
+
+## Running the development server
+
+Once dependencies are installed you can start the server:
+
+```powershell
+npm start
+```
+
+or, equivalently:
+
+```powershell
+node server.js
+```
+
+The server listens on port `3000`. Open <http://localhost:3000/> in your browser to use the UI. The terminal will display `Server is running at http://0.0.0.0:3000` when the service is ready.
+
+If the environment has no internet access the server automatically falls back to the curated offline catalogue stored in `data/fallback-games.json`.
+
+## Stopping the server
+
+Press `Ctrl+C` in the terminal where the server is running to stop it.
+
+## Troubleshooting
+
+- **`npm` is not recognised** – Make sure Node.js is installed and that you opened a new PowerShell/Command Prompt window after the installation so that the `PATH` variable is refreshed.
+- **Port 3000 is busy** – Stop the other program that is using the port or edit `server.js` and change the value of `PORT`.
+- **No Steam data** – When offline the server serves placeholder data. Reconnect to the internet to get live data from Steam.
+
+## Project structure
+
+```
+Vibecoding/
+├── data/                # Offline catalogue used when Steam is unreachable
+├── public/              # Static assets served to the browser (HTML, CSS, JS)
+├── server.js            # Node.js server entry point
+├── package.json         # npm scripts and metadata
+└── README.md            # This document
+```
+

--- a/data/fallback-games.json
+++ b/data/fallback-games.json
@@ -1,0 +1,44 @@
+[
+  {
+    "aliases": ["portal 2", "portal2", "portal", "портал", "портал 2"],
+    "name": "Portal 2",
+    "description": "Кооперативная и одиночная головоломка от Valve, продолжающая историю лаборатории Aperture Science и приключений Челл и Уитли.",
+    "headerImage": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPlBvcnRhbCAyPC90ZXh0Pjwvc3ZnPg==",
+    "screenshots": [
+      {
+        "thumbnail": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMTcwIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjE3MCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMzIiIGZpbGw9IiNjN2Q1ZTAiPlBvcnRhbCAyPC90ZXh0Pjwvc3ZnPg==",
+        "full": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPlBvcnRhbCAyPC90ZXh0Pjwvc3ZnPg=="
+      }
+    ],
+    "steamAppId": 620,
+    "storePage": "https://store.steampowered.com/app/620"
+  },
+  {
+    "aliases": ["half-life 2", "half life 2", "half life", "half-life"],
+    "name": "Half-Life 2",
+    "description": "Продолжение культового шутера от Valve про возвращение Гордона Фримена и сопротивление Альянсу.",
+    "headerImage": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPkhhbGYtTGlmZSAyPC90ZXh0Pjwvc3ZnPg==",
+    "screenshots": [
+      {
+        "thumbnail": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMTcwIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjE3MCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMzIiIGZpbGw9IiNjN2Q1ZTAiPkhhbGYtTGlmZSAyPC90ZXh0Pjwvc3ZnPg==",
+        "full": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPkhhbGYtTGlmZSAyPC90ZXh0Pjwvc3ZnPg=="
+      }
+    ],
+    "steamAppId": 220,
+    "storePage": "https://store.steampowered.com/app/220"
+  },
+  {
+    "aliases": ["dota 2", "dota", "дота", "дота 2"],
+    "name": "Dota 2",
+    "description": "Командная MOBA, в которой две команды по пять игроков сражаются за контроль над картой и Трон противника.",
+    "headerImage": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPkRvdGEgMjwvdGV4dD48L3N2Zz4=",
+    "screenshots": [
+      {
+        "thumbnail": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMTcwIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjE3MCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMzIiIGZpbGw9IiNjN2Q1ZTAiPkRvdGEgMjwvdGV4dD48L3N2Zz4=",
+        "full": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIj48cmVjdCB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgZmlsbD0iIzFiMjgzOCIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNjQiIGZpbGw9IiNjN2Q1ZTAiPkRvdGEgMjwvdGV4dD48L3N2Zz4="
+      }
+    ],
+    "steamAppId": 570,
+    "storePage": "https://store.steampowered.com/app/570"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vibecoding",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Steam Game Finder</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1 class="title">Steam Game Finder</h1>
+      <p class="subtitle">
+        Введите название игры, чтобы найти её баннер, описание и скриншоты из Steam.
+      </p>
+      <form id="search-form" class="search-form">
+        <label for="game-name" class="visually-hidden">Название игры</label>
+        <input
+          type="text"
+          id="game-name"
+          name="game-name"
+          placeholder="Например, Counter-Strike 2"
+          required
+        />
+        <button type="submit">Найти</button>
+      </form>
+
+      <section id="status" class="status" aria-live="polite"></section>
+
+      <section id="results" class="results" hidden>
+        <div class="banner">
+          <img id="game-banner" alt="Баннер игры" loading="lazy" />
+        </div>
+        <div class="info">
+          <h2 id="game-title"></h2>
+          <p id="game-description"></p>
+          <a id="game-link" href="#" target="_blank" rel="noopener" class="store-link">
+            Открыть страницу игры в Steam
+          </a>
+        </div>
+        <div class="screenshots">
+          <h3>Скриншоты</h3>
+          <div id="screenshots-grid" class="screenshots-grid"></div>
+        </div>
+      </section>
+    </main>
+
+    <template id="screenshot-template">
+      <figure class="screenshot-card">
+        <img src="" alt="Скриншот игры" loading="lazy" />
+        <figcaption>
+          <a href="" target="_blank" rel="noopener">Открыть в полном размере</a>
+        </figcaption>
+      </figure>
+    </template>
+
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -29,7 +29,15 @@ form.addEventListener('submit', async (event) => {
 
     const game = await response.json();
     renderGame(game);
-    showStatus('Готово! Вот что удалось найти.', 'success');
+
+    if (game.offline) {
+      showStatus(
+        'Steam сейчас недоступен. Показаны заранее подготовленные данные.',
+        'warning'
+      );
+    } else {
+      showStatus('Готово! Вот что удалось найти.', 'success');
+    }
   } catch (error) {
     console.error(error);
     resultsSection.hidden = true;
@@ -81,9 +89,13 @@ function showStatus(message, type) {
 }
 
 function toggleLoading(isLoading) {
-  form.querySelector('button').disabled = isLoading;
-  form.querySelector('button').textContent = isLoading ? 'Ищем…' : 'Найти';
-  showStatus(isLoading ? 'Запрашиваем данные в Steam…' : '', 'info');
+  const button = form.querySelector('button');
+  button.disabled = isLoading;
+  button.textContent = isLoading ? 'Ищем…' : 'Найти';
+
+  if (isLoading) {
+    showStatus('Запрашиваем данные в Steam…', 'info');
+  }
 }
 
 async function safeJson(response) {

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,95 @@
+const form = document.getElementById('search-form');
+const input = document.getElementById('game-name');
+const statusEl = document.getElementById('status');
+const resultsSection = document.getElementById('results');
+const bannerImg = document.getElementById('game-banner');
+const titleEl = document.getElementById('game-title');
+const descriptionEl = document.getElementById('game-description');
+const linkEl = document.getElementById('game-link');
+const screenshotsGrid = document.getElementById('screenshots-grid');
+const screenshotTemplate = document.getElementById('screenshot-template');
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const query = input.value.trim();
+
+  if (!query) {
+    showStatus('Пожалуйста, введите название игры.', 'error');
+    return;
+  }
+
+  toggleLoading(true);
+  try {
+    const response = await fetch(`/api/game?name=${encodeURIComponent(query)}`);
+
+    if (!response.ok) {
+      const errorData = await safeJson(response);
+      throw new Error(errorData?.error || 'Не удалось получить данные об игре.');
+    }
+
+    const game = await response.json();
+    renderGame(game);
+    showStatus('Готово! Вот что удалось найти.', 'success');
+  } catch (error) {
+    console.error(error);
+    resultsSection.hidden = true;
+    showStatus(error.message || 'Произошла ошибка. Попробуйте ещё раз.', 'error');
+  } finally {
+    toggleLoading(false);
+  }
+});
+
+function renderGame(game) {
+  bannerImg.src = game.headerImage;
+  bannerImg.alt = `Баннер игры ${game.name}`;
+  titleEl.textContent = game.name;
+  descriptionEl.textContent = game.description;
+  linkEl.href = game.storePage;
+  linkEl.hidden = !game.storePage;
+
+  screenshotsGrid.innerHTML = '';
+
+  if (Array.isArray(game.screenshots) && game.screenshots.length > 0) {
+    const fragment = document.createDocumentFragment();
+
+    game.screenshots.forEach((shot, index) => {
+      const node = screenshotTemplate.content.cloneNode(true);
+      const image = node.querySelector('img');
+      const anchor = node.querySelector('a');
+
+      image.src = shot.thumbnail || shot.full;
+      image.alt = `Скриншот ${index + 1} из игры ${game.name}`;
+      anchor.href = shot.full || shot.thumbnail;
+
+      fragment.appendChild(node);
+    });
+
+    screenshotsGrid.appendChild(fragment);
+  } else {
+    const message = document.createElement('p');
+    message.className = 'no-screenshots';
+    message.textContent = 'Скриншоты для этой игры не найдены.';
+    screenshotsGrid.appendChild(message);
+  }
+
+  resultsSection.hidden = false;
+}
+
+function showStatus(message, type) {
+  statusEl.textContent = message;
+  statusEl.dataset.statusType = type;
+}
+
+function toggleLoading(isLoading) {
+  form.querySelector('button').disabled = isLoading;
+  form.querySelector('button').textContent = isLoading ? 'Ищем…' : 'Найти';
+  showStatus(isLoading ? 'Запрашиваем данные в Steam…' : '', 'info');
+}
+
+async function safeJson(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -108,6 +108,10 @@ body {
   color: rgba(148, 163, 184, 0.9);
 }
 
+.status[data-status-type='warning'] {
+  color: #f5c451;
+}
+
 .results[hidden] {
   display: none;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,242 @@
+:root {
+  color-scheme: dark light;
+  --bg-color: #0f172a;
+  --text-color: #f8fafc;
+  --accent-color: #38bdf8;
+  --accent-color-hover: #0ea5e9;
+  --card-bg: rgba(15, 23, 42, 0.7);
+  --border-color: rgba(148, 163, 184, 0.3);
+  font-family: 'Segoe UI', Roboto, system-ui, -apple-system, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 60%),
+    linear-gradient(160deg, #020617 0%, #0f172a 40%, #0b1120 100%);
+  color: var(--text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.container {
+  width: min(960px, 100%);
+  background-color: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.5);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.25rem, 2.5vw + 1.5rem, 3rem);
+  text-align: center;
+}
+
+.subtitle {
+  margin: 0.75rem auto 2rem;
+  text-align: center;
+  max-width: 32rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.search-form {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.search-form input {
+  flex: 1 1 280px;
+  padding: 0.9rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-form input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.search-form button {
+  padding: 0.9rem 1.6rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color-hover));
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-form button:hover,
+.search-form button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
+.status {
+  text-align: center;
+  min-height: 1.5rem;
+  color: rgba(148, 163, 184, 0.9);
+  margin-bottom: 1.5rem;
+}
+
+.status[data-status-type='success'] {
+  color: #a3e635;
+}
+
+.status[data-status-type='error'] {
+  color: #f87171;
+}
+
+.status[data-status-type='info'] {
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.results[hidden] {
+  display: none;
+}
+
+.results {
+  display: grid;
+  gap: 2rem;
+}
+
+.banner {
+  display: flex;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.banner img {
+  width: min(100%, 640px);
+  border-radius: 12px;
+  object-fit: cover;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.5);
+}
+
+.info {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+#game-description {
+  margin: 0 auto;
+  max-width: 50ch;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.store-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.95);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.store-link:hover,
+.store-link:focus-visible {
+  transform: translateY(-2px);
+  background: #f8fafc;
+  outline: none;
+}
+
+.screenshots {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.screenshots-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.screenshot-card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.screenshot-card img {
+  width: 100%;
+  display: block;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.screenshot-card figcaption {
+  padding: 0.75rem 1rem;
+  margin-top: auto;
+  text-align: center;
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.screenshot-card a {
+  color: var(--accent-color);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.screenshot-card a:hover,
+.screenshot-card a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 2rem 1.5rem;
+  }
+
+  .search-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-form button {
+    width: 100%;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,169 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const HOST = '0.0.0.0';
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+
+    if (requestUrl.pathname === '/api/game' && req.method === 'GET') {
+      await handleGameLookup(requestUrl, res);
+      return;
+    }
+
+    await serveStaticFile(requestUrl.pathname, res);
+  } catch (error) {
+    console.error('Server error:', error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal server error' }));
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Server is running at http://${HOST}:${PORT}`);
+});
+
+async function handleGameLookup(url, res) {
+  const name = url.searchParams.get('name');
+
+  if (!name || !name.trim()) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Пожалуйста, укажите название игры.' }));
+    return;
+  }
+
+  try {
+    const searchUrl = new URL('https://store.steampowered.com/api/storesearch/');
+    searchUrl.searchParams.set('term', name);
+    searchUrl.searchParams.set('cc', 'ru');
+
+    const searchResponse = await fetch(searchUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; VibecodingBot/1.0; +https://example.com)'
+      }
+    });
+
+    if (!searchResponse.ok) {
+      throw new Error(`Steam search request failed with status ${searchResponse.status}`);
+    }
+
+    const searchData = await searchResponse.json();
+    const items = Array.isArray(searchData?.items) ? searchData.items : [];
+
+    const app = items.find((entry) => entry.type === 'app') || items[0];
+
+    if (!app) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Игры с таким названием не найдено в Steam.' }));
+      return;
+    }
+
+    const appId = app.id;
+
+    const detailsUrl = new URL('https://store.steampowered.com/api/appdetails');
+    detailsUrl.searchParams.set('appids', appId);
+    detailsUrl.searchParams.set('cc', 'ru');
+    detailsUrl.searchParams.set('l', 'russian');
+
+    const detailsResponse = await fetch(detailsUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; VibecodingBot/1.0; +https://example.com)'
+      }
+    });
+
+    if (!detailsResponse.ok) {
+      throw new Error(`Steam details request failed with status ${detailsResponse.status}`);
+    }
+
+    const detailsData = await detailsResponse.json();
+    const appData = detailsData?.[appId];
+
+    if (!appData?.success || !appData?.data) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Не удалось получить информацию об игре.' }));
+      return;
+    }
+
+    const gameData = appData.data;
+
+    const responsePayload = {
+      name: gameData.name,
+      description: gameData.short_description,
+      headerImage: gameData.header_image,
+      screenshots: Array.isArray(gameData.screenshots)
+        ? gameData.screenshots.map((shot) => ({
+            thumbnail: shot.path_thumbnail,
+            full: shot.path_full,
+          }))
+        : [],
+      steamAppId: gameData.steam_appid,
+      storePage: `https://store.steampowered.com/app/${gameData.steam_appid}`,
+    };
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(responsePayload));
+  } catch (error) {
+    console.error('Steam API error:', error);
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error:
+          'Не удалось получить данные из Steam. Попробуйте ещё раз чуть позже.',
+      })
+    );
+  }
+}
+
+async function serveStaticFile(requestPath, res) {
+  const safePath = requestPath === '/' ? '/index.html' : requestPath;
+  const decodedPath = decodeURIComponent(safePath);
+  const filePath = path.normalize(path.join(PUBLIC_DIR, decodedPath));
+
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Доступ запрещён');
+    return;
+  }
+
+  try {
+    const fileStat = await fs.promises.stat(filePath);
+
+    if (fileStat.isDirectory()) {
+      await streamFile(path.join(filePath, 'index.html'), res);
+    } else {
+      await streamFile(filePath, res);
+    }
+  } catch (error) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Файл не найден');
+  }
+}
+
+async function streamFile(filePath, res) {
+  const ext = path.extname(filePath);
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+  res.writeHead(200, { 'Content-Type': contentType });
+  const stream = fs.createReadStream(filePath);
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+    stream.pipe(res);
+  });
+}

--- a/server.js
+++ b/server.js
@@ -1,6 +1,12 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const dns = require('dns');
+
+// Steam endpoints иногда отдают IPv6-адреса, которые недоступны в части окружений
+// (в таком случае Node.js генерирует ошибку ENETUNREACH). Принудительно просим
+// резолвить IPv4-адреса в первую очередь, чтобы сделать проксирование устойчивым.
+dns.setDefaultResultOrder('ipv4first');
 
 const PORT = process.env.PORT || 3000;
 const HOST = '0.0.0.0';
@@ -17,6 +23,9 @@ const MIME_TYPES = {
   '.svg': 'image/svg+xml',
   '.ico': 'image/x-icon',
 };
+
+const FALLBACK_DATA_PATH = path.join(__dirname, 'data', 'fallback-games.json');
+const fallbackGames = loadFallbackGames(FALLBACK_DATA_PATH);
 
 const server = http.createServer(async (req, res) => {
   try {
@@ -120,6 +129,27 @@ async function handleGameLookup(url, res) {
     res.end(JSON.stringify(responsePayload));
   } catch (error) {
     console.error('Steam API error:', error);
+    const fallback = findFallbackGame(name);
+
+    if (fallback) {
+      console.warn('Используем офлайн-данные для игры:', fallback.name);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          name: fallback.name,
+          description: fallback.description,
+          headerImage: fallback.headerImage,
+          screenshots: Array.isArray(fallback.screenshots)
+            ? fallback.screenshots
+            : [],
+          steamAppId: fallback.steamAppId,
+          storePage: fallback.storePage,
+          offline: true,
+        })
+      );
+      return;
+    }
+
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(
       JSON.stringify({
@@ -166,4 +196,52 @@ async function streamFile(filePath, res) {
     stream.on('end', resolve);
     stream.pipe(res);
   });
+}
+
+function loadFallbackGames(filePath) {
+  try {
+    const file = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(file);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('Не удалось загрузить офлайн-данные игр:', error.message);
+  }
+
+  return [];
+}
+
+function findFallbackGame(query) {
+  if (!query) {
+    return null;
+  }
+
+  const normalized = query.trim().toLowerCase();
+
+  return (
+    fallbackGames.find((game) => {
+      if (!game || typeof game !== 'object') {
+        return false;
+      }
+
+      const aliases = Array.isArray(game.aliases) ? game.aliases : [];
+      const aliasMatch = aliases.some((alias) => {
+        const aliasNormalized = typeof alias === 'string' ? alias.trim().toLowerCase() : '';
+
+        if (!aliasNormalized) {
+          return false;
+        }
+
+        return (
+          normalized.includes(aliasNormalized) ||
+          aliasNormalized.includes(normalized)
+        );
+      });
+      const nameMatch = typeof game.name === 'string' &&
+        game.name.trim().toLowerCase() === normalized;
+
+      return aliasMatch || nameMatch;
+    }) || null
+  );
 }


### PR DESCRIPTION
## Summary
- add a lightweight Node.js server that serves static assets and proxies requests to Steam store endpoints
- build a single-page interface for searching games and presenting the banner, description, and screenshots
- include client-side UX for loading states, errors, and screenshot gallery rendering

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68cc4cd865e48324b81835460d23dd70