### PR TITLE
Fix ensure-env to normalize SQLite database URL

### DIFF
--- a/scripts/ensure-env.js
+++ b/scripts/ensure-env.js
@@ -28,7 +28,7 @@ try {
     'SUGGESTIONS_HTTP_ENDPOINT'
   ];
 
-  const envContent = fs.readFileSync(envPath, 'utf8');
+  let envContent = fs.readFileSync(envPath, 'utf8');
   const exampleContent = fs.readFileSync(examplePath, 'utf8');
   const missingKeys = requiredKeys.filter((key) => !new RegExp(`^${key}=`, 'm').test(envContent));
 
@@ -42,6 +42,55 @@ try {
 
     fs.appendFileSync(envPath, `\n${additions}\n`);
     console.log(`[ensure-env] Добавлены отсутствующие ключи в .env: ${missingKeys.join(', ')}`);
+    envContent = fs.readFileSync(envPath, 'utf8');
+  }
+
+  const prismaSchemaPath = path.join(projectRoot, 'prisma', 'schema.prisma');
+  let usesSqlite = false;
+
+  if (fs.existsSync(prismaSchemaPath)) {
+    try {
+      const schemaContent = fs.readFileSync(prismaSchemaPath, 'utf8');
+      const datasourceMatch = schemaContent.match(/datasource\s+\w+\s*{[^}]*?provider\s*=\s*"([^"]+)"/s);
+
+      if (datasourceMatch && datasourceMatch[1] === 'sqlite') {
+        usesSqlite = true;
+      }
+    } catch (schemaError) {
+      console.warn('[ensure-env] Не удалось прочитать prisma/schema.prisma для определения провайдера БД:', schemaError);
+    }
+  }
+
+  if (usesSqlite) {
+    const envLines = envContent.split(/\r?\n/);
+    const dbUrlIndex = envLines.findIndex((line) => /^DATABASE_URL\s*=/.test(line));
+
+    if (dbUrlIndex !== -1) {
+      const valueMatch = envLines[dbUrlIndex].match(/^DATABASE_URL\s*=\s*(.+)$/);
+
+      if (valueMatch) {
+        let rawValue = valueMatch[1].trim();
+        let quote = '';
+
+        if (rawValue.length >= 2 && ((rawValue.startsWith('"') && rawValue.endsWith('"')) || (rawValue.startsWith("'") && rawValue.endsWith("'")))) {
+          quote = rawValue[0];
+          rawValue = rawValue.slice(1, -1);
+        }
+
+        const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawValue);
+
+        if (rawValue && !hasScheme) {
+          const normalizedPath = rawValue.startsWith('./') || rawValue.startsWith('../') || rawValue.startsWith('/')
+            ? rawValue
+            : `./${rawValue}`;
+          const updatedValue = `file:${normalizedPath}`;
+          envLines[dbUrlIndex] = `DATABASE_URL=${quote ? `${quote}${updatedValue}${quote}` : updatedValue}`;
+          envContent = envLines.join('\n');
+          fs.writeFileSync(envPath, `${envContent}\n`);
+          console.log('[ensure-env] DATABASE_URL приведён к формату file: для SQLite.');
+        }
+      }
+    }
   }
 
   if (/^GAS_BASE_URL=.*YOUR_SCRIPT_ID/m.test(envContent)) {


### PR DESCRIPTION
## Summary
- ensure the generated .env keeps DATABASE_URL compatible with SQLite by automatically prepending the file: scheme when it is missing
- detect the datasource provider from prisma/schema.prisma and avoid changing non-SQLite setups
- keep .env content in sync after adding missing keys

## Testing
- node scripts/ensure-env.js

------
https://chatgpt.com/codex/tasks/task_e_68d863d90f3c8324a67637506196bd34